### PR TITLE
Allow the user to choose the command to run for their specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Available commands:
 This extension contributes the following settings:
 
 ```json
+"ruby.specCommand": {
+    "type": "string",
+    "default": "",
+    "description": "Defines a custom command to run for specs (i.e. 'spring rspec')"
+},
 "ruby.specGem": {
     "type": "string",
     "default": "rspec",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
         "configuration": {
             "title": "Ruby Spec Test Configurations",
             "properties": {
+                "ruby.specCommand": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Defines a custom command to run for specs (i.e. 'spring rspec')"
+                },
                 "ruby.specGem": {
                     "type": "string",
                     "default": "rspec",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -69,7 +69,7 @@ function executeInTerminal(fileName, options) {
 function getSpecCommand() {
     if (customSpecCommand()) {
         return customSpecCommand();
-    } elseif (isZeusActive()) {
+    } else if (isZeusActive()) {
         return 'zeus test';
     } else {
         return 'bundle exec rspec';

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -67,11 +67,17 @@ function executeInTerminal(fileName, options) {
 }
 
 function getSpecCommand() {
-    if (isZeusActive()) {
+    if (customSpecCommand()) {
+        return customSpecCommand();
+    } elseif (isZeusActive()) {
         return 'zeus test';
     } else {
         return 'bundle exec rspec';
     }
+}
+
+function customSpecCommand() {
+    return vscode.workspace.getConfiguration("ruby").get('specCommand');
 }
 
 function isZeusActive() {


### PR DESCRIPTION
We use spring, not zeus, and `spring rspec` greatly speeds up my development process, but there is no way to do this automatically with this extension. This change allows the user to define a custom command to run, if desired, instead of switching based on the gem they're using.