### PR TITLE
Convert rails implementation path to spec path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Available commands:
 Also there is an option to run any `file` or `folder` specs from sidebar.
 **Right click** an folder or spec file and choose `Run Specs` option.
 
+You can also run spec for currently open file, the extension will try to guess the path using Rails convention:
+
+`app/controllers/test_controller.rb => spec/controllers/test_controller_spec.rb`
+
 ## Extension Settings
 
 This extension contributes the following settings:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rails-run-spec-vscode",
     "displayName": "Rails Run Specs",
     "description": "Rails Run Spec Files",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "publisher": "noku",
     "icon": "rspec.png",
     "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.5.0"
+        "vscode": "^1.6.0"
     },
     "repository": {
         "type": "git",
@@ -117,6 +117,7 @@
         "typescript": "^2.0.3",
         "typings": "^2.1.0",
         "mocha": "^2.3.3",
+        "vscode": "^1.0.0",
         "@types/node": "^6.0.40",
         "@types/mocha": "^2.2.32"
     }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,5 +1,6 @@
 'use strict';
 import * as vscode from 'vscode';
+import toSpecPath from './utils/toSpecPath';
 
 let lastCommandText;
 let activeTerminals = {};
@@ -111,11 +112,4 @@ function isSpec(fileName: string) {
 
 function isSpecDirectory(fileName: string) {
     return fileName.indexOf('spec') > -1 && fileName.indexOf('.rb') == -1
-}
-
-function toSpecPath(filePath: string) {
-    let [first, ...rest] = filePath.split('/');
-    let middle = rest.slice(0, rest.length - 1);
-    let last = rest[rest.length - 1];
-    return ['spec', ...middle , last.replace('.rb', '_spec.rb')].join('/');
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -14,7 +14,7 @@ vscode.window.onDidCloseTerminal((terminal: vscode.Terminal) => {
 
 export function runSpecFile(options: {path?: string; lineNumber?: number; commandText?: string} = {}){
     let editor: vscode.TextEditor = vscode.window.activeTextEditor,
-        fileName: string = vscode.workspace.asRelativePath(options.path || editor.document.fileName);
+        fileName: string = toSpecPath(vscode.workspace.asRelativePath(options.path || editor.document.fileName))
 
     if (!editor || !isSpecDirectory(fileName) && !isSpec(fileName) && !options.commandText) {
         return;
@@ -111,4 +111,11 @@ function isSpec(fileName: string) {
 
 function isSpecDirectory(fileName: string) {
     return fileName.indexOf('spec') > -1 && fileName.indexOf('.rb') == -1
+}
+
+function toSpecPath(filePath: string) {
+    let [first, ...rest] = filePath.split('/');
+    let middle = rest.slice(0, rest.length - 1);
+    let last = rest[rest.length - 1];
+    return ['spec', ...middle , last.replace('.rb', '_spec.rb')].join('/');
 }

--- a/src/utils/toSpecPath.ts
+++ b/src/utils/toSpecPath.ts
@@ -1,0 +1,6 @@
+export default function toSpecPath(filePath: string) {
+    let [first, ...rest] = filePath.split('/');
+    let middle = rest.slice(0, rest.length - 1);
+    let last = rest[rest.length - 1];
+    return ['spec', ...middle , last.replace('.rb', '_spec.rb')].join('/');
+}

--- a/src/utils/toSpecPath.ts
+++ b/src/utils/toSpecPath.ts
@@ -1,6 +1,10 @@
 export default function toSpecPath(filePath: string) {
     let [first, ...rest] = filePath.split('/');
-    let middle = rest.slice(0, rest.length - 1);
-    let last = rest[rest.length - 1];
-    return ['spec', ...middle , last.replace('.rb', '_spec.rb')].join('/');
+    if (filePath.match(/_spec\.rb/) || first === 'spec') {
+        return filePath
+    } else {
+        let middle = rest.slice(0, rest.length - 1);
+        let filename = rest[rest.length - 1];
+        return ['spec', ...middle, filename.replace('.rb', '_spec.rb')].join('/');
+    }
 }

--- a/test/utils/toSpecPath.test.ts
+++ b/test/utils/toSpecPath.test.ts
@@ -16,4 +16,11 @@ suite("toSpecPath", () => {
             toSpecPath('app/controllers/namespaces/admin/test_controller.rb')
         );
     });
+
+    test("Converting spec path should be no-op", () => {
+        assert.equal(
+            'spec/controllers/namespaces/admin/test_controller_spec.rb',
+            toSpecPath('spec/controllers/namespaces/admin/test_controller_spec.rb')
+        );
+    })
 });

--- a/test/utils/toSpecPath.test.ts
+++ b/test/utils/toSpecPath.test.ts
@@ -4,7 +4,10 @@ import toSpecPath from '../../src/utils/toSpecPath';
 
 suite("toSpecPath", () => {
     test("Converting shallow path", () => {
-        assert.equal('spec/controllers/test_controller_spec.rb', toSpecPath('app/controllers/test_controller.rb'));
+        assert.equal(
+            'spec/controllers/test_controller_spec.rb',
+            toSpecPath('app/controllers/test_controller.rb')
+        );
     });
 
     test("Converting deep path", () => {

--- a/test/utils/toSpecPath.test.ts
+++ b/test/utils/toSpecPath.test.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+
+import toSpecPath from '../../src/utils/toSpecPath';
+
+suite("toSpecPath", () => {
+    test("Converting shallow path", () => {
+        assert.equal('spec/controllers/test_controller_spec.rb', toSpecPath('app/controllers/test_controller.rb'));
+    });
+
+    test("Converting deep path", () => {
+        assert.equal(
+            'spec/controllers/namespaces/admin/test_controller_spec.rb',
+            toSpecPath('app/controllers/namespaces/admin/test_controller.rb')
+        );
+    });
+});


### PR DESCRIPTION
As Rails user, I want to be able to run specs for currently opened file instead of having to open spec file itself. By convention the path to spec is converted as following

`app/controllers/comments_controller.rb => spec/controllers/comments_controller_spec.rb` 

so it's pretty easy to guess what's the spec path is and run it.

I also added first test to check if it's working correctly.

Besides I bumped vscode engine version as 1.5.0 doesn't have `onDidCloseTerminal` support, so it resolves #2.

Thanks for your work to create this extension!