### PR TITLE
Update File Spec command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Available commands:
 ```json
 [
     {
-        "command": "extension.runSpecFile",
-        "title": "Run File Spec",
+        "command": "extension.runFileSpecs",
+        "title": "Run File Specs",
         "key": "cmd+shift+t"
     },
     {


### PR DESCRIPTION
To verify:
- Add a custom key binding in VSCode for the command: `extensions.runSpecFile`. Run this key binding and you'll see a "command not found" error.
- Add a custom key binding in VSCode for the command: `extensions.runFileSpecs`. Run this key binding. This should trigger the command successfully.