### PR TITLE
Make extension work with workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.6.0"
+        "vscode": "^1.19.0"
     },
     "repository": {
         "type": "git",
@@ -46,7 +46,7 @@
                 "title": "Run Last Spec"
             }
         ],
-        "keybindings":[
+        "keybindings": [
             {
                 "command": "extension.runFileSpecs",
                 "key": "cmd+shift+t"
@@ -101,7 +101,7 @@
                     "default": 2000
                 },
                 "ruby.specSaveFile": {
-                    "type":"boolean",
+                    "type": "boolean",
                     "description": "Auto Save file before running spec test",
                     "default": false
                 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,7 +15,7 @@ vscode.window.onDidCloseTerminal((terminal: vscode.Terminal) => {
 
 export function runSpecFile(options: {path?: string; lineNumber?: number; commandText?: string}){
     let editor: vscode.TextEditor = vscode.window.activeTextEditor,
-        fileName: string = toSpecPath(vscode.workspace.asRelativePath(options.path || editor.document.fileName))
+        fileName: string = toSpecPath(vscode.workspace.asRelativePath(options.path || editor.document.fileName, false))
 
     if (!editor || !isSpecDirectory(fileName) && !isSpec(fileName) && !options.commandText) {
         return;


### PR DESCRIPTION
# Background
There was an issue when trying to run the specs if using workspaces
see #15 this PR fixes the problem by relying on a new version of the vscode
extension engine that allows us to pass in a boolean depending on if we want
the workspace name to be in the path.  See https://code.visualstudio.com/docs/extensionAPI/vscode-api

# Changes
- Update the engine version to get the new `asRelativePath` behavoior
- Call `asRelativePath` without including workspace folder
