### PR TITLE
Run specs for files outside the 'app' folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## New Features
+
+To develop new features execute the following steps:
+
+1. `git clone` the repository
+2. Run `npm install`
+3. Open VSCode
+4. Go to the `Debug` side menu
+5. Select the `Launch Tests` options and press play
+6. Once the tests pass, you're ready to go!

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
                 "title": "Run Last Spec"
             }
         ],
-        "keybindings":[
+        "keybindings": [
             {
                 "command": "extension.runFileSpecs",
                 "key": "cmd+shift+t"
@@ -101,7 +101,7 @@
                     "default": 2000
                 },
                 "ruby.specSaveFile": {
-                    "type":"boolean",
+                    "type": "boolean",
                     "description": "Auto Save file before running spec test",
                     "default": false
                 }

--- a/src/utils/toSpecPath.ts
+++ b/src/utils/toSpecPath.ts
@@ -1,10 +1,13 @@
 export default function toSpecPath(filePath: string) {
     let [first, ...rest] = filePath.split('/');
+    let middle = rest.slice(0, rest.length - 1);
+    let filename = rest[rest.length - 1];
+
     if (filePath.match(/_spec\.rb/) || first === 'spec') {
         return filePath
+    } else if (first !== 'app') {
+        return ['spec', first, ...middle, filename.replace('.rb', '_spec.rb')].join('/');
     } else {
-        let middle = rest.slice(0, rest.length - 1);
-        let filename = rest[rest.length - 1];
         return ['spec', ...middle, filename.replace('.rb', '_spec.rb')].join('/');
     }
 }

--- a/test/utils/toSpecPath.test.ts
+++ b/test/utils/toSpecPath.test.ts
@@ -23,4 +23,12 @@ suite("toSpecPath", () => {
             toSpecPath('spec/controllers/namespaces/admin/test_controller_spec.rb')
         );
     })
+    suite("when current file is not inside 'app' folder", () => {
+        test("it should preserve the whole path", () => {
+            assert.equal(
+                'spec/lib/utils/custom_calculator_spec.rb',
+                toSpecPath('lib/utils/custom_calculator.rb')
+            );
+        })
+    });
 });


### PR DESCRIPTION
- With this change, specs for files in unconventional folders (like `lib`) will also be found (as long as the spec path mirrors the impl. path).

- I also wrote a mini CONTRIBUTING guide to help new developers.