### PR TITLE
Add config to use forward slashes in path regardless of OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
         "configuration": {
             "title": "Ruby Spec Test Configurations",
             "properties": {
+                "ruby.specUseForwardSlashesInPaths": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Defines if spec paths should always use forward slashes regardless of OS"
+                },
                 "ruby.specCommand": {
                     "type": "string",
                     "default": "",

--- a/src/utils/toSpecPath.ts
+++ b/src/utils/toSpecPath.ts
@@ -1,10 +1,16 @@
+import * as vscode from 'vscode';
+
 export default function toSpecPath(filePath: string, pattern: string) {
     let [first, ...rest] = filePath.split('/');
+    let specPath;
     if (filePath.indexOf(`_${pattern}.rb`) > -1 || first === pattern) {
-        return filePath
+        specPath = filePath
     } else {
         let middle = rest.slice(0, rest.length - 1);
         let filename = rest[rest.length - 1];
-        return [pattern, ...middle, filename.replace('.rb', `_${pattern}.rb`)].join('/');
+        specPath = [pattern, ...middle, filename.replace('.rb', `_${pattern}.rb`)].join('/');
     }
+
+    const useForwardSlashes = vscode.workspace.getConfiguration("ruby").get("specUseForwardSlashesInPaths"); 
+    return useForwardSlashes ? specPath.split('\\').join('/') : specPath ;
 }


### PR DESCRIPTION
I use WSL and had issues running the specs since the VSCode API will return backslashes on Windows (relates to https://github.com/noku/rails-run-spec-vscode/issues/21), but WSL expects forward slashes. This is a workaround, adding a config for users to specify if the path should always use forward slashes, and does a simple replacement of backslashes. 

If VSCode adds a config to define the separator, then we can remove this later https://github.com/Microsoft/vscode/issues/35593.

@noku, what do you think?