### PR TITLE
Use a different terminal for each workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "rails-run-spec-vscode",
     "displayName": "Rails Run Specs",
     "description": "Rails Run Spec Files",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "publisher": "noku",
     "icon": "rspec.png",
     "galleryBanner": {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -27,7 +27,7 @@ export function runSpecFile(options: {path?: string; lineNumber?: number; comman
         vscode.window.activeTextEditor.document.save();
     }
 
-    let isZeusInit = isZeusActive() && !activeTerminals[ZEUS_TERMINAL_NAME];
+    let isZeusInit = isZeusActive() && !activeTerminals[getTerminalName(ZEUS_TERMINAL_NAME)];
 
     if (isZeusInit) {
         zeusTerminalInit();
@@ -55,10 +55,10 @@ export function runLastSpec() {
 }
 
 function executeInTerminal(fileName, options) {
-    let specTerminal: vscode.Terminal = activeTerminals[SPEC_TERMINAL_NAME];
+    let specTerminal: vscode.Terminal = activeTerminals[getTerminalName(SPEC_TERMINAL_NAME)];
 
     if (!specTerminal) {
-        specTerminal = vscode.window.createTerminal(SPEC_TERMINAL_NAME);
+        specTerminal = vscode.window.createTerminal(getTerminalName(SPEC_TERMINAL_NAME));
         activeTerminals[SPEC_TERMINAL_NAME] = specTerminal;
     }
 
@@ -80,6 +80,13 @@ function executeCommand(specTerminal, fileName, options) {
     specTerminal.sendText(commandText);
 
     lastCommandText = commandText;
+}
+
+function getTerminalName(prefix) {
+    return [
+        prefix,
+        vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).name
+    ].join(' ');
 }
 
 function getSpecCommand() {
@@ -117,8 +124,9 @@ function getZeusStartTimeout(): number {
 }
 
 function zeusTerminalInit() {
-    let zeusTerminal = vscode.window.createTerminal(ZEUS_TERMINAL_NAME)
-    activeTerminals[ZEUS_TERMINAL_NAME] = zeusTerminal;
+    const terminalName = getTerminalName(ZEUS_TERMINAL_NAME);
+    let zeusTerminal = vscode.window.createTerminal(terminalName)
+    activeTerminals[terminalName] = zeusTerminal;
     zeusTerminal.sendText("zeus start");
 }
 


### PR DESCRIPTION
I have a workspace with a rails project and several gem projects loaded. The run spec command works everywhere but it'll get confused if I leave the terminal window open - its in the wrong starting folder.

This change makes it use the workspace name as part of the terminal name so that each workspace folder gets its own terminal.

<img width="267" alt="screen shot 2018-10-19 at 4 28 12 pm" src="https://user-images.githubusercontent.com/8016/47196225-01a98780-d3bc-11e8-9569-19414cfb42cc.png">


Fixes #15 