### PR TITLE
Support lib directory with toSpecPath

### DIFF
--- a/src/utils/toSpecPath.ts
+++ b/src/utils/toSpecPath.ts
@@ -1,10 +1,12 @@
 export default function toSpecPath(filePath: string, pattern: string) {
-    let [first, ...rest] = filePath.split('/');
-    if (filePath.indexOf(`_${pattern}.rb`) > -1 || first === pattern) {
+    let middle = filePath.split('/');
+    let first  = middle.shift()
+    let last   = middle.pop()
+
+    if (last.indexOf(`_${pattern}.rb`) > -1 || first === pattern) {
         return filePath
     } else {
-        let middle = rest.slice(0, rest.length - 1);
-        let filename = rest[rest.length - 1];
-        return [pattern, ...middle, filename.replace('.rb', `_${pattern}.rb`)].join('/');
+        let dirPath = first === 'app' ? [pattern, ...middle] : [pattern, first, ...middle];
+        return [...dirPath, last.replace('.rb', `_${pattern}.rb`)].join('/');
     }
 }

--- a/test/utils/toSpecPath.test.ts
+++ b/test/utils/toSpecPath.test.ts
@@ -17,6 +17,20 @@ suite("toSpecPath", () => {
         );
     });
 
+    test("Converting shallow lib path", () => {
+        assert.equal(
+            'spec/lib/test_spec.rb',
+            toSpecPath('lib/test.rb', "spec")
+        );
+    });
+
+    test("Converting deep lib path", () => {
+        assert.equal(
+            'spec/lib/capistrano/tasks/test_spec.rb',
+            toSpecPath('lib/capistrano/tasks/test.rb', "spec")
+        );
+    });
+
     test("Converting spec path should be no-op", () => {
         assert.equal(
             'spec/controllers/namespaces/admin/test_controller_spec.rb',


### PR DESCRIPTION
I want to be able to test the lib directory.

`toSpecPath('lib/capistrano/tasks/test.rb', "spec") # => 'spec/lib/test_spec.rb'`