### PR TITLE
Update keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,19 +54,19 @@
     "keybindings": [
       {
         "command": "extension.runAllSpecFiles",
-        "key": "cmd+r"
+        "key": "cmd+ctrl+r"
       },
       {
         "command": "extension.runFileSpecs",
-        "key": "cmd+shift+t"
+        "key": "cmd+ctrl+t"
       },
       {
         "command": "extension.runSpecLine",
-        "key": "cmd+l"
+        "key": "cmd+ctrl+l"
       },
       {
         "command": "extension.runLastSpec",
-        "key": "cmd+y"
+        "key": "cmd+ctrl+y"
       }
     ],
     "menus": {


### PR DESCRIPTION
Implements: https://github.com/noku/rails-run-spec-vscode/issues/14

## Summary

Updates all keybindings to use `cmd+ctrl+XXX` to avoid overwriting commonly used default keybindings.

#### Previously overwritten keybindings
`cmd+y`: `redo`
`cmd+l`: `expandLineSelection`
`cmd+shift+t`: `reopenClosedEditor`
`cmd+r`: `gotoSymbol`
